### PR TITLE
Disallow non null assertion by default

### DIFF
--- a/src/configs/typescript.mjs
+++ b/src/configs/typescript.mjs
@@ -83,7 +83,7 @@ export default {
     "@typescript-eslint/no-meaningless-void-operator": "error",
     "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
     "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
-    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-restricted-imports": "off",
     "@typescript-eslint/no-throw-literal": "error",


### PR DESCRIPTION
Not sure if there is a special reason for turning off it at first.